### PR TITLE
fix bad path in doc example

### DIFF
--- a/docs-src/tutorials/writing-react-components.md
+++ b/docs-src/tutorials/writing-react-components.md
@@ -20,7 +20,7 @@ const AdminBroOptions = {
 Dashboard component: `./my-dashboard-component.jsx`
 ```
 import React from 'react'
-import { Box } from 'admin-bro'
+import { Box } from '@admin-bro/design-system'
 
 const Dashboard = (props) => {
   return (


### PR DESCRIPTION
I noticed a pretty significant error in the documentation which caused me a lot of problems when developing my first custom component. On the [writing react tutorial components page](https://adminbro.com/tutorial-writing-react-components.html) under the section "Example of overriding how dashboard looks:" the sample component code is incorrect. Instead of

`import { Box } from 'admin-bro'`

it should read

`import { Box } from '@admin-bro/design-system'`

Importing any component from admin-bro causes the UI to render an error (image attached). Searching through Admin bro's slack channel shows a lot of other people had this same issue.